### PR TITLE
update xarray tiling page to point to new titiler-multidim url

### DIFF
--- a/approaches/tiling.qmd
+++ b/approaches/tiling.qmd
@@ -4,9 +4,9 @@ title: "Tiling"
 
 An xarray tile server provides image tiles via the [XYZ Protocol](https://en.wikipedia.org/wiki/Tiled_web_map) and [OGC Tiles](https://docs.ogc.org/is/20-057/20-057.html) API specifications.
 
-The tile server approach relies on the [`rio_tiler.XarrayReader`](https://github.com/cogeotiff/rio-tiler/blob/main/rio_tiler/io/xarray.py) library which includes the `tile` function. This module supports tiling of anything that is xarray-readable, so a tile server using this library can render tiles from Zarr stores as well as netCDF4/HDF5 and other formats. An example API infrastructure can be found in [titiler-xarray](https://github.com/developmentseed/titiler-xarray). Please note this library is still in development and is not intended for production use at this time.
+The tile server approach relies on the [`rio_tiler.XarrayReader`](https://github.com/cogeotiff/rio-tiler/blob/main/rio_tiler/io/xarray.py) library which includes the `tile` function. This module supports tiling of anything that is xarray-readable, so a tile server using this library can render tiles from Zarr stores as well as netCDF4/HDF5 and other formats. An example API infrastructure can be found in [titiler-multidim](https://github.com/developmentseed/titiler-multidim). Please note this library is still in development and is not intended for production use at this time.
 
-Users can preview their zarr data using the map form and preview tool at [https://dev-titiler-xarray.delta-backend.com/WebMercatorQuad/map](https://dev-titiler-xarray.delta-backend.com/WebMercatorQuad/map).
+Users can preview their zarr data using the map form and preview tool at [https://staging.openveda.cloud/api/multidim/WebMercatorQuad/map](https://staging.openveda.cloud/api/multidim/WebMercatorQuad/map).
 
 ![](../images/zarr-preview.gif)
 


### PR DESCRIPTION
The old titiler-xarray API has been replaced by a new titiler-multidim API in SMCE Staging!

ref: https://github.com/developmentseed/titiler-multidim/issues/78